### PR TITLE
FPGA program not done due to DCI matching failure

### DIFF
--- a/tcl/topdown.tcl
+++ b/tcl/topdown.tcl
@@ -200,6 +200,8 @@ report_timing_summary -file $outputDir/$instance-post-route-timing-summary.txt
 report_timing -sort_by group -max_paths 100 -path_type summary -file $outputDir/$instance-post-route-timing.txt > $outputDir/temp.log
 report_io -file $outputDir/$instance-post-route-io.txt > $outputDir/temp.log
 report_datasheet -file $outputDir/$instance-post-route_datasheet.txt > $outputDir/temp.log
+set_property "BITSTREAM.STARTUP.MATCH_CYCLE" NoWait [current_design]
+
 if {[info exists env(BITFILE)] && $env(BITFILE) != ""} {
 	## commented out -logic_location_file for now because the files are huge -Jamey
 	#log_command "write_xdc -no_fixed_only -force $outputDir/$instance-post-route.xdc" $outputDir/write_bitstream.log


### PR DESCRIPTION
If DCI matching fails, FPGA is not programmed properly by default.
Setting "BITSTREAM.STARTUP.MATCH_CYCLE" NoWait makes FPGA programmed
successfully without checking DCI matching.